### PR TITLE
Separate metadata and data in config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ prettytable-rs = "0.8.0"
 lazy_static = "1.3.0"
 uuid = { version = "0.7.4", features = ["serde", "v4"] }
 human-panic = "1.0.1"
+syntect = "3.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,29 +3,10 @@
 
 use serde::{Deserialize, Serialize};
 
-
-// Struct that hold Cell style configuration. This allows a user to configure
-// the style of different Cells according to his/her style
-#[derive(Serialize, Deserialize)]
-pub struct CellStyle{
-
-    // Style for the ID column
-    pub id: String,
-
-    // Style for the subject column
-    pub subject: String,
-
-    // Style for the tags column
-    pub tags: String,
-
-    // Style for the data output
-    pub data: String,
-}
-
 // This struct represents the configuration of tips
 //
 // TODO replace String type for the fields below to Path type
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
 
     // db_file field holds the path to the database file.
@@ -43,20 +24,7 @@ pub struct Config {
     pub editor: String,
 
     // Color definitions
-    pub cell_styles: CellStyle,
-}
-
-impl std::fmt::Display for Config {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        writeln!(f, "db_file:            {}", self.db_file)?;
-        writeln!(f, "tmp_file:           {}", self.tmp_file)?;
-        writeln!(f, "editor:             {}", self.editor)?;
-        writeln!(f, "Cell style id:      {}", self.cell_styles.id)?;
-        writeln!(f, "Cell style subject: {}", self.cell_styles.subject)?;
-        writeln!(f, "Cell style tags:    {}", self.cell_styles.tags)?;
-        writeln!(f, "Cell style data:    {}", self.cell_styles.data)?;
-        Ok(())
-    }
+    pub style: Style,
 }
 
 impl Config {
@@ -70,7 +38,7 @@ impl Config {
         let data = match serde_yaml::to_string(&*self) {
             Ok(string) => string,
             Err(err)   => {
-                panic!("Error when serializing Config struc: {}\n{}",
+                panic!("Error when serializing Config struc: {:?}\n{}",
                        self, err);
             },
         };
@@ -107,3 +75,39 @@ impl Config {
         }
     }
 }
+
+
+// Struct describing the style for table output
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TableStyle {
+    // Style for the ID column
+    pub id: String,
+
+    // Style for the subject column
+    pub subject: String,
+
+    // Style for the tags column
+    pub tags: String,
+}
+
+
+// Struct that hold data style configuration
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DataStyle {
+
+    // Set theme for data output
+    pub theme: String,
+}
+
+
+// Struct that hold style configuration for table and data
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Style {
+
+    // Style for prettytable output
+    pub table: TableStyle,
+
+    // Style for the data output
+    pub data: DataStyle,
+}
+

--- a/src/init.rs
+++ b/src/init.rs
@@ -92,13 +92,20 @@ fn create_tipsrc() {
         data:        TIPS.get("data").unwrap().to_string(),
         editor:      TIPS.get("editor").unwrap().to_string(),
 
-        // The cell styles are intentionally set to an empty string,
-        // it's up to the user to change this after his/her style
-        cell_styles: crate::config::CellStyle {
-            id: "".to_string(),
-            subject: "".to_string(),
-            tags: "".to_string(),
-            data: "".to_string(),
+        style: crate::config::Style {
+
+            // The cell styles are intentionally set to an empty string,
+            // it's up to the user to change this after his/her style
+            table: crate::config::TableStyle {
+                id: "".to_string(),
+                subject: "".to_string(),
+                tags: "".to_string(),
+            },
+
+            // Let's expect that everyone runs Solarized dark theme... I do
+            data: crate::config::DataStyle {
+                theme: "Solarized (dark)".to_string(),
+            },
         },
     };
 
@@ -120,6 +127,7 @@ fn create_database() {
                     subject: "My first tip".to_string(),
                     id: Some(1),
                     tags: vec!["tip".to_string()],
+                    data_extension: Some(String::from("txt")),
                 },
                 data: uuid,
             }
@@ -137,6 +145,10 @@ Welcome to T(ips)
 
     Colored output
     --------------
+
+    Below applies for Tip summary output, that means when listing Tips and also
+    the header when showing the data contents of a tip.
+
 	Prettytable supports setting a style on a Cell. Tips configuration ~/.tipsrc
     contain an empty style. By changing that string you can get the style you
     prefer.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,6 +17,10 @@ pub struct Metadata {
 
     // The tags list holds tags for the Tip.
     pub tags: Vec<String>,
+
+    // This field is used to do syntax highlighting by file extention. Meaning
+    // that if the code is Rust use "rs" as extension.
+    pub data_extension: Option<String>,
 }
 
 // Implement PartialEq trait for Metadata, so we can compare two Metadata
@@ -25,7 +29,8 @@ impl PartialEq for Metadata {
     fn eq(&self, other: &Metadata) -> bool {
         self.subject == other.subject &&
             self.id == other.id &&
-            self.tags == other.tags
+            self.tags == other.tags &&
+            self.data_extension == other.data_extension
     }
 }
 
@@ -37,8 +42,8 @@ impl fmt::Display for Metadata {
         };
         write!(
             f,
-            "subject: {}\nid: {}\ntags: {:?}]\n",
-            self.subject, _id, self.tags,
+            "subject: {}\nid: {}\ntags: {:?}]\ncode_extension: {:?}",
+            self.subject, _id, self.tags, self.data_extension
         )
     }
 }

--- a/src/tip.rs
+++ b/src/tip.rs
@@ -13,12 +13,13 @@ pub static TIP: TipTemplate = TipTemplate {
 r##"subject:
 tags:
   - notag
------ TIP BELOW THIS LINE -----
+data_extension:
+----- TIP DATA BELOW THIS LINE -----
 "##,
 
     // The separator is inserted after the template and act as a separator
     // to the tip data. The separator is not included in the stored Tip.
-    separator: "----- TIP BELOW THIS LINE -----",
+    separator: "----- TIP DATA BELOW THIS LINE -----",
 };
 
 // Struct that holds the Tip template and separator fields
@@ -79,7 +80,7 @@ impl Tip {
     fn id_cell(&self) -> prettytable::Cell {
         let mut cell = prettytable::Cell::new(
             &format!("{}", self.metadata.id.unwrap()))
-            .style_spec(&CONFIG.cell_styles.id);
+            .style_spec(&CONFIG.style.table.id);
 
         cell.align(prettytable::format::Alignment::LEFT);
         cell.set_hspan(4);
@@ -91,7 +92,7 @@ impl Tip {
     fn subject_cell(&self) -> prettytable::Cell {
         let mut cell = prettytable::Cell::new(
             &format!("{}", self.metadata.subject))
-            .style_spec(&CONFIG.cell_styles.subject);
+            .style_spec(&CONFIG.style.table.subject);
 
         cell.align(prettytable::format::Alignment::LEFT);
         cell.set_hspan(4);
@@ -113,7 +114,7 @@ impl Tip {
         // Create the cell with the string created
         // and set the style, alignment
         let mut cell = prettytable::Cell::new(&tag_string)
-            .style_spec(&CONFIG.cell_styles.tags);
+            .style_spec(&CONFIG.style.table.tags);
 
         cell.align(prettytable::format::Alignment::RIGHT);
         cell.set_hspan(4);
@@ -166,15 +167,12 @@ impl Tip {
 
         // Read the data contents
         let data_file = format!("{}/{}", &CONFIG.data, &self.data);
-        let content = crate::helpers::read_to_string(&data_file);
+        let data = crate::helpers::read_to_string(&data_file);
 
-        // Create a cell for the data
-        let mut tip = prettytable::Cell::new(&content)
-            .style_spec(&CONFIG.cell_styles.data);
-        tip.align(prettytable::format::Alignment::LEFT);
-        tip.set_hspan(0);
-
-        // Present the tip
-        crate::present::present_tip(self.header_cells(), tip);
+        // Present the
+        crate::present::present_tip(
+            self.header_cells(),
+            &data,
+            self.metadata.data_extension.clone());
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -87,6 +87,7 @@ fn update_metadata(tip: &mut crate::tip::Tip, metadata: &String) {
     if tip != &tmp_tip {
         tip.metadata.subject = tmp_tip.metadata.subject;
         tip.metadata.tags = tmp_tip.metadata.tags;
+        tip.metadata.data_extension = tmp_tip.metadata.data_extension;
     }
 }
 


### PR DESCRIPTION
Also added support for syntax highlighting based on the file extension
of data contents. The file extension can be set in metadata of Tip.

Change-Id: I6f5f1d7bdb7e6764290ec8ddc11a48495a91c06c