### PR TITLE
Fix so when stdout is not a terminal for show subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ uuid = { version = "0.7.4", features = ["serde", "v4"] }
 human-panic = "1.0.1"
 syntect = "3.2"
 chrono = { version = "0.4", features = ["serde"] }
+atty = "0.2.11"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ and store information from the command line.
 - Clone repo
 - cargo build --release --bin tips --target-dir <path>
 - tips init
-  
+
 # Configure Tips
 Edit ~/.tipsrc
+
+The following environment variables are used to control specific behaviour:
+- TIPS_SHOW_NOHEADER : When set Tips do not print Tip header when running 'show'

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate serde;
 extern crate serde_yaml;
 extern crate regex;
 extern crate chrono;
+extern crate atty;
 mod helpers;
 mod init;
 mod query;


### PR DESCRIPTION
This means when redirecting the output there is no syntax highlight
performed.

Also if the env variable TIPS_SHOW_NOHEADER is present, then show
subcommand will not print the Tip header.

Change-Id: I0bb0c18ef2d78adca924bd141c0b85d1e73a2f6b